### PR TITLE
feat: add option to customize if not enter in vehicle

### DIFF
--- a/client/menus/main.lua
+++ b/client/menus/main.lua
@@ -137,6 +137,7 @@ menu.onClose = function()
     if QBCore then
         TriggerServerEvent("customs:server:saveVehicleProps")
     end
+    MENUOPEN = false
 end
 
 lib.callback.register('customs:client:vehicleProps', function()

--- a/client/zones.lua
+++ b/client/zones.lua
@@ -3,7 +3,6 @@ local QBCore
 local allowAccess = false
 MENUOPEN = false
 PROMPTOPEN = false
-local inside = false
 
 if GetResourceState('qb-core') == 'started' then
     QBCore = exports['qb-core']:GetCoreObject()
@@ -62,17 +61,15 @@ CreateThread(function()
                 lib.hideTextUI()
                 MENUOPEN = false
                 PROMPTOPEN = false
-                inside = false
             end,
             inside = function()
-                inside = true
                 --[[if IsControlJustPressed(0, 38) and cache.vehicle and allowAccess then
                     SetEntityVelocity(cache.vehicle, 0.0, 0.0, 0.0)
                     lib.hideTextUI()
                     MENUOPEN = true
                     require('client.menus.main')()
                 end]]--
-                while inside do
+                
                     if not PROMPTOPEN and IsPedInAnyVehicle(PlayerPedId(), false) then
                         lib.showTextUI('Press [E] to tune your car', {
                             icon = 'fa-solid fa-car',
@@ -90,8 +87,7 @@ CreateThread(function()
                         MENUOPEN = true
                         require('client.menus.main')()
                     end
-                    Wait(0)
-                end
+                    Wait(10)
             end,
         })
 

--- a/client/zones.lua
+++ b/client/zones.lua
@@ -1,6 +1,9 @@
 local zoneId
 local QBCore
 local allowAccess = false
+MENUOPEN = false
+PROMPTOPEN = false
+local inside = false
 
 if GetResourceState('qb-core') == 'started' then
     QBCore = exports['qb-core']:GetCoreObject()
@@ -52,16 +55,42 @@ CreateThread(function()
                     icon = 'fa-solid fa-car',
                     position = 'left-center',
                 })
+                PROMPTOPEN = true
             end,
             onExit = function()
                 zoneId = nil
                 lib.hideTextUI()
+                MENUOPEN = false
+                PROMPTOPEN = false
+                inside = false
             end,
             inside = function()
-                if IsControlJustPressed(0, 38) and cache.vehicle and allowAccess then
+                inside = true
+                --[[if IsControlJustPressed(0, 38) and cache.vehicle and allowAccess then
                     SetEntityVelocity(cache.vehicle, 0.0, 0.0, 0.0)
                     lib.hideTextUI()
+                    MENUOPEN = true
                     require('client.menus.main')()
+                end]]--
+                while inside do
+                    if not PROMPTOPEN and IsPedInAnyVehicle(PlayerPedId(), false) then
+                        lib.showTextUI('Press [E] to tune your car', {
+                            icon = 'fa-solid fa-car',
+                            position = 'left-center',
+                        })
+                        PROMPTOPEN = true
+                    end
+                    if  PROMPTOPEN and not IsPedInAnyVehicle(PlayerPedId(), false) then
+                        lib.hideTextUI()
+                        PROMPTOPEN = false
+                    end
+                    if IsControlJustPressed(0, 38) and IsPedInAnyVehicle(PlayerPedId(), false) and allowAccess then
+                        SetEntityVelocity(cache.vehicle, 0.0, 0.0, 0.0)
+                        lib.hideTextUI()
+                        MENUOPEN = true
+                        require('client.menus.main')()
+                    end
+                    Wait(0)
                 end
             end,
         })

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -7,7 +7,7 @@ author 'Jorn#0008'
 name 'popcornrp-customs'
 description 'Customs script using ox_lib'
 repository 'https://github.com/alberttheprince/popcornrp-customs'
-version '1.4.0'
+version '1.5.0'
 
 ui_page 'web/index.html'
 


### PR DESCRIPTION
If you walk into the mechanic shop and enter a vehicle, then press E you will be able to customize it rather than having to drive the vehicle out of the zone and back in to get the menu prompt.