### PR TITLE
feat(world): add excluded services support at locations

### DIFF
--- a/client/menus/main.lua
+++ b/client/menus/main.lua
@@ -1,3 +1,5 @@
+local ServiceScope = require('client.utils.enums.ServiceScope')
+
 mainLastIndex = 1
 vehicle = 0
 mainMenuId = 'customs-main'
@@ -6,6 +8,7 @@ local inMenu = false
 local dragcam = require('client.dragcam')
 local startDragCam = dragcam.startDragCam
 local stopDragCam = dragcam.stopDragCam
+local serviceDict
 
 if GetResourceState('qb-core') == 'started' then
     QBCore = exports['qb-core']:GetCoreObject()
@@ -22,6 +25,16 @@ local menu = {
 
 local function main()
     if GetVehicleBodyHealth(vehicle) < 1000.0 then
+        if not serviceDict[ServiceScope.Repair] then
+            lib.notify({
+                title = 'Customs',
+                description = 'You cannot do anything here until your vehicle is repaired.',
+                position = 'top',
+                type = 'error'
+            })
+            return -- do not return repair option if it's excluded
+        end
+
         return {{
             label = 'Repair',
             description = ('%s%d'):format(Config.Currency, math.ceil(1000 - GetVehicleBodyHealth(vehicle))),
@@ -29,29 +42,40 @@ local function main()
         }}
     end
 
-    local options = {
-        {
+    local options = {}
+    if serviceDict[ServiceScope.Performance] then
+        options[#options + 1] = {
             label = 'Performance',
             close = true,
             args = {
                 menu = 'client.menus.performance',
             }
-        },
-        {
+        }
+    end
+
+    if serviceDict[ServiceScope.Parts] then
+        options[#options + 1] = {
             label = 'Cosmetics - Parts',
             close = true,
             args = {
                 menu = 'client.menus.parts',
             }
-        },
-        {
+        }
+    end
+
+    if serviceDict[ServiceScope.Colors] then
+        options[#options + 1] = {
             label = 'Cosmetics - Colors',
             close = true,
             args = {
                 menu = 'client.menus.colors',
             }
-        },
-    }
+        }
+    end
+
+    if not serviceDict[ServiceScope.Extra] then
+        return options
+    end
 
     local hasExtras = false
     for i = 1, 14 do
@@ -151,11 +175,53 @@ lib.callback.register('customs:client:vehicleProps', function()
     return QBCore.Functions.GetVehicleProperties(vehicle)
 end)
 
-return function()
+---@param excludedServices integer[]
+---@param service integer
+---@return boolean
+local function isServiceIncluded(excludedServices, service)
+    for i = 1, #excludedServices do
+        if excludedServices[i] == service then
+            return false
+        end
+    end
+
+    return true
+end
+
+---@param excludedServices integer[]
+---@return table<string, true>
+local function getIncludedServiceDict(excludedServices)
+    local services = {}
+    local isAnyServiceIncluded = false
+
+    for _, service in pairs(ServiceScope) do
+        if isServiceIncluded(excludedServices, service) then
+            services[service] = true
+            isAnyServiceIncluded = true
+        end
+    end
+
+
+    assert(
+        isAnyServiceIncluded,
+        "No services are included. The provided excludedServices list filters out all available services."
+    )
+
+    return services
+end
+
+---@param excludedServices number[]|nil
+return function(excludedServices)
     if not cache.vehicle or inMenu then return end
+    serviceDict = excludedServices
+        and getIncludedServiceDict(excludedServices)
+        or ServiceScope
+
     vehicle = cache.vehicle
     SetVehicleModKit(vehicle, 0)
-    menu.options = main()
+    local options = main()
+    if not options then return end
+    menu.options = options
     lib.registerMenu(menu, onSubmit)
     lib.showMenu(menu.id, 1)
     disableControls()

--- a/client/utils/enums/ServiceScope.lua
+++ b/client/utils/enums/ServiceScope.lua
@@ -1,0 +1,8 @@
+---@enum ServiceScope
+return {
+    Repair = 0,
+    Performance = 1,
+    Parts = 2,
+    Colors = 3,
+    Extra = 4,
+}

--- a/client/zones.lua
+++ b/client/zones.lua
@@ -65,7 +65,7 @@ CreateThread(function()
                 if IsControlJustPressed(0, 38) and cache.vehicle and allowAccess then
                     SetEntityVelocity(cache.vehicle, 0.0, 0.0, 0.0)
                     lib.hideTextUI()
-                    require('client.menus.main')()
+                    require('client.menus.main')(v.excludedServices or {})
                 end
             end,
         })

--- a/config.lua
+++ b/config.lua
@@ -1,3 +1,5 @@
+local ServiceScope = require('client.utils.enums.ServiceScope')
+
 Config = {}
 
 Config.Currency = '$'
@@ -18,23 +20,34 @@ Config.Zones = {
 --             vec3(-319.43, -130.65, 38.60),
 --             vec3(-324.77, -147.93, 38.60),
 --             vec3(-348.59, -139.1, 38.60),
+--         },
+--         excludedServices = {
+--             ServiceScope.Parts,
+--             ServiceScope.Performance,
 --         }
 --     },
 
 -- Default GTA 5 Customs and Benny's Locations
     {
-	blipLabel = "Los Santos Customs - Vinewood",
-	blipColor = 5,
+	    blipLabel = "Los Santos Customs - Vinewood",
+	    blipColor = 5,
         points = {
             vec3(-344.36, -121.92, 38.60),
             vec3(-319.43, -130.65, 38.60),
             vec3(-324.77, -147.93, 38.60),
             vec3(-348.59, -139.1, 38.60),
-        }
+        },
+        -- Disables repair, performance and parts services for the Vinewood Customs zone.
+        -- If the vehicle is damaged, no services will be available here because repairs are disabled.
+        -- excludedServices = {
+        --     ServiceScope.Repair,
+        --     ServiceScope.Performance,
+        --     ServiceScope.Parts,
+        -- }
     },
     {
-	blipLabel = "Los Santos Customs - Airport",
-	blipColor = 5,
+	    blipLabel = "Los Santos Customs - Airport",
+	    blipColor = 5,
         points = {
             vec3(-1147.7, -1990.31, 13.15),
             vec3(-1171.05, -2013.96, 13.15),
@@ -44,8 +57,8 @@ Config.Zones = {
         }
     },
     {
-	blipLabel = "Los Santos Customs - East",
-	blipColor = 5,
+	    blipLabel = "Los Santos Customs - East",
+	    blipColor = 5,
         points = {
             vec3(724.93, -1092.04, 22.15),
             vec3(738.52, -1094.83, 22.15),
@@ -54,8 +67,8 @@ Config.Zones = {
         }
     },
     {
-	blipLabel = "Los Santos Customs - Sandy Shores",
-	blipColor = 5,
+	    blipLabel = "Los Santos Customs - Sandy Shores",
+	    blipColor = 5,
         points = {
             vec3(1172.12, 2644.76, 38.55),
             vec3(1171.39, 2635.66, 38.55),
@@ -64,8 +77,8 @@ Config.Zones = {
         }
     },
     {
-	blipLabel = "Los Santos Customs - Paleto",
-	blipColor = 5,
+	    blipLabel = "Los Santos Customs - Paleto",
+	    blipColor = 5,
         points = {
             vec3(115.55, 6625.32, 31.75),
             vec3(109.19, 6631.69, 31.75),
@@ -74,15 +87,15 @@ Config.Zones = {
         }
     },
     {
-	blipLabel = "Benny's Motorworks",
-	blipColor = 5,
+	    blipLabel = "Benny's Motorworks",
+	    blipColor = 5,
         points = {
             vec3(-203.55, -1311.26, 30.85),
             vec3(-228.06, -1319.24, 30.85),
             vec3(-228.25, -1334.25, 30.85),
             vec3(-214.18, -1341.38, 30.85),
-	    vec3(-195.42, -1321.19, 30.85),
-	    vec3(-195.26, -1314.11, 30.85),
+	        vec3(-195.42, -1321.19, 30.85),
+	        vec3(-195.26, -1314.11, 30.85),
         }
     },
 }

--- a/types.lua
+++ b/types.lua
@@ -7,3 +7,4 @@
 ---@field blipLabel string? -- Name for the blip on the map
 ---@field blipColor number? -- Color for the blip on the map
 ---@field points vector3[] -- Array of points that make up the zone
+---@field excludedServices integer[]? -- Array of services to exclude in zone


### PR DESCRIPTION
**Proposed Changes**

- Added configuration support for excluding vehicle‑modification menu options in specific locations.
- Implemented logic to block vehicle repairs in locations where repairs are not available, requiring players to arrive with an undamaged vehicle.

**Notes**

- This change is not breaking, because the configuration uses an exclusion model. Existing setups continue to work without requiring new configuration entries.
- I did not notice any server‑side abuse‑prevention logic related to these features, so I did not add additional safeguards.

**Checklist**

- [x] New code cleaned up and formatted
- [x] Performed smoke tests in affected locations

Resolves #37 